### PR TITLE
Not working in my environment, so I fixed the relevant part.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,3 @@
 ```bash
 npm i typedoc-plugin-remove-references
 ```
-
-Add `typedoc-plugin-remove-references` to typedoc [options](https://typedoc.org/guides/options/#plugin).
-
-```typescript
-{
-  plugin: ['typedoc-plugin-remove-references']
-}
-```

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "devDependencies": {
     "@types/node": "^13.9.0",
-    "typedoc": "^0.19.2",
-    "typescript": "^3.7.5"
+    "typedoc": "^0.22.10",
+    "typescript": "^4.4.3"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { Application, ReflectionKind } from 'typedoc';
-import { Converter } from 'typedoc/dist/lib/converter';
+import { Application, ReflectionKind,Converter } from 'typedoc';
 export function load({ application }: { application: Application }) {
   application.converter.on(Converter.EVENT_RESOLVE_BEGIN, context => {
     for (const reflection of context.project.getReflectionsByKind(ReflectionKind.Reference)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Application, ReflectionKind,Converter } from 'typedoc';
 export function load({ application }: { application: Application }) {
-  application.converter.on(Converter.EVENT_RESOLVE_BEGIN, context => {
+  application.converter.on(Converter.EVENT_RESOLVE_BEGIN, (context:any) => {
     for (const reflection of context.project.getReflectionsByKind(ReflectionKind.Reference)) {
       context.project.removeReflection(reflection)
     }


### PR DESCRIPTION
Hello.
An error occurred after the build.

+ Cause :
https://github.com/s-n-1-0/typedoc-plugin-remove-references/commit/238fb089230bc8f6f14a748c3704033122d8a84b

+ Environment : 
TypeDoc v0.22.10 [Node.js 14.18.2, TypeScript v4.4]

Also, "plugin" item is no longer needed with the TypeDoc update.